### PR TITLE
Modernize calendar header with gradient and SVG silhouette

### DIFF
--- a/header-silhouette.svg
+++ b/header-silhouette.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <path fill="currentColor" d="M0 20V10C20 0 40 0 60 10s40 10 40 10V0H0z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,20 @@
         position: relative;
         overflow: hidden;
         border: 1px solid var(--secondary-color);
-        color: var(--text-dark);
+        color: var(--text-light);
+        background: linear-gradient(
+          135deg,
+          var(--primary-color),
+          var(--secondary-color)
+        );
+      }
+      .calendar-header::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: url("header-silhouette.svg") no-repeat bottom/cover;
+        opacity: 0.2;
+        pointer-events: none;
       }
       .calendar-month-year {
         text-align: center;


### PR DESCRIPTION
## Summary
- Restyle calendar header with a gradient and light text
- Overlay a subtle SVG wave as a silhouette backdrop

## Testing
- `npx prettier@3 index.html header-silhouette.svg --write` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prettier)*
- `prettier index.html`

------
https://chatgpt.com/codex/tasks/task_e_68c4e23abcb8832db61548ff9dafe1ff