### PR TITLE
Prefetch five surrounding Hijri months

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,20 +483,26 @@
         specialDates.innerHTML = "";
 
         try {
-          const prevYear =
-            currentHijri.month === 1 ? currentHijri.year - 1 : currentHijri.year;
-          const prevMonthNum =
-            currentHijri.month === 1 ? 12 : currentHijri.month - 1;
-          const nextYear =
-            currentHijri.month === 12 ? currentHijri.year + 1 : currentHijri.year;
-          const nextMonthNum =
-            currentHijri.month === 12 ? 1 : currentHijri.month + 1;
+          // Fetch current month along with two previous and two next months
+          const offsets = [-2, -1, 0, 1, 2];
+          const monthsToFetch = offsets.map((offset) => {
+            let month = currentHijri.month + offset;
+            let year = currentHijri.year;
+            while (month < 1) {
+              month += 12;
+              year--;
+            }
+            while (month > 12) {
+              month -= 12;
+              year++;
+            }
+            return { year, month };
+          });
 
-          const [currMonth, prevMonth, nextMonth] = await Promise.all([
-            getHijriMonth(currentHijri.year, currentHijri.month),
-            getHijriMonth(prevYear, prevMonthNum),
-            getHijriMonth(nextYear, nextMonthNum),
-          ]);
+          const [prevPrevMonth, prevMonth, currMonth, nextMonth, nextNextMonth] =
+            await Promise.all(
+              monthsToFetch.map((m) => getHijriMonth(m.year, m.month))
+            ); // prevPrevMonth & nextNextMonth are prefetched for caching
           if (!currMonth.length) {
             console.error("No calendar data");
             return;

--- a/index.html
+++ b/index.html
@@ -652,30 +652,52 @@
         }
       }
 
+      // Prefetch additional months in the direction of navigation
+      function prefetchExtraMonths(direction) {
+        const offsets = direction === "next" ? [3, 4] : direction === "prev" ? [-3, -4] : [];
+        offsets.forEach((offset) => {
+          let month = currentHijri.month + offset;
+          let year = currentHijri.year;
+          while (month < 1) {
+            month += 12;
+            year--;
+          }
+          while (month > 12) {
+            month -= 12;
+            year++;
+          }
+          getHijriMonth(year, month);
+        });
+      }
+
       // Navigation event listeners
-      prevMonthBtn.addEventListener("click", () => {
+      prevMonthBtn.addEventListener("click", async () => {
         if (--currentHijri.month < 1) {
           currentHijri.month = 12;
           currentHijri.year--;
         }
-        renderCalendar();
+        await renderCalendar();
+        prefetchExtraMonths("prev");
       });
 
-      nextMonthBtn.addEventListener("click", () => {
+      nextMonthBtn.addEventListener("click", async () => {
         if (++currentHijri.month > 12) {
           currentHijri.month = 1;
           currentHijri.year++;
         }
-        renderCalendar();
+        await renderCalendar();
+        prefetchExtraMonths("next");
       });
 
-      todayBtn.addEventListener("click", () => {
+      todayBtn.addEventListener("click", async () => {
         if (!todayHijri) return;
         currentHijri = {
           year: todayHijri.year,
           month: todayHijri.month.number,
         };
-        renderCalendar();
+        await renderCalendar();
+        prefetchExtraMonths("next");
+        prefetchExtraMonths("prev");
       });
 
       // Generic fetch helper function


### PR DESCRIPTION
## Summary
- Prefetch two previous and two next Hijri months along with the current month
- Simplify month calculations to always retrieve a five-month window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c690e365c0832dbc808370b7bbe9b8